### PR TITLE
Add Linux support via _start() and exit() stubs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,23 @@ on:
     branches: [ main ]
 
 jobs:
-  build-and-test:
+  Linux:
+    runs-on: ubuntu-20.04
+    name: "Ubuntu 20.04"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Download Ninja
+        run: curl -OL https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip
+
+      - name: Unzip Ninja
+        run: unzip ninja-linux.zip
+
+      - name: Build and run tests
+        run: ./ninja -f build-linux.ninja test
+
+  macOS:
     runs-on: macos-10.15
     name: "macOS 10.15"
     steps:
@@ -38,4 +54,4 @@ jobs:
         run: unzip ninja-mac.zip
 
       - name: Build and run tests
-        run: ./ninja test
+        run: ./ninja -f build-macos.ninja test

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ Xcode
 *.a
 *.o
 *.o.d
-.ninja_log
+.ninja_*
 tests/complex_test_2_5
 tests/complex_test_3_8

--- a/build-linux.ninja
+++ b/build-linux.ninja
@@ -15,28 +15,21 @@
 libc = lib/include
 clang-args =
 clang-cflags = -fno-builtin -nostdlib -std=c99 -I$libc -Wall
-# Note: you need to add a symlink in the local directory that points to the
-# appropriate version of Xcode you want to use; e.g.:
-#
-#     $ ln -s /Applications/Xcode_12.5.app Xcode
-#
-# Since `ninja` doesn't accept flags nor does a `build.ninja` read from
-# environment variables, we need a level of indirection to be able to substitute
-# different versions of Xcode locally vs. what's used in GitHub Actions.
-Xcode_UsrLib = Xcode/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib
 
 rule clang
   depfile = $out.d
-  command = clang -MD -MF $out.d ${clang-cflags} ${clang-args} -c $in -o $out
+  command = clang -O2 -MD -MF $out.d ${clang-cflags} ${clang-args} -c $in -o $out
 
 rule ar
   command = ar -crs $out $in
 
-rule ld-mac
-  command = ld -arch x86_64 -execute $in -lSystem -L${Xcode_UsrLib} -o $out
+rule ld
+  command = ld $in lib/libc.a -o $out
 
 build lib/complex.o: clang lib/complex.c
-build lib/libc.a: ar lib/complex.o
+build lib/crt0.o: clang lib/crt0.c
+build lib/stdlib.o: clang lib/stdlib.c
+build lib/libc.a: ar lib/complex.o lib/crt0.o lib/stdlib.o
 
 rule exit_with_status_code
   command = tests/exit_with_status_code.sh ${expected-status} ${subcommand}
@@ -45,7 +38,7 @@ rule exit_with_status_code
 build tests/complex_test_2_5.o: clang tests/complex_test.c
   clang-args = -DREAL=2 -DIMAG=5
 
-build tests/complex_test_2_5: ld-mac tests/complex_test_2_5.o lib/libc.a
+build tests/complex_test_2_5: ld tests/complex_test_2_5.o lib/libc.a
 
 build run_complex_test_2_5: exit_with_status_code tests/complex_test_2_5
   expected-status = 7
@@ -55,7 +48,7 @@ build run_complex_test_2_5: exit_with_status_code tests/complex_test_2_5
 build tests/complex_test_3_8.o: clang tests/complex_test.c
   clang-args = -DREAL=3 -DIMAG=8
 
-build tests/complex_test_3_8: ld-mac tests/complex_test_3_8.o
+build tests/complex_test_3_8: ld tests/complex_test_3_8.o
 
 build run_complex_test_3_8: exit_with_status_code tests/complex_test_3_8
   expected-status = 11

--- a/build-macos.ninja
+++ b/build-macos.ninja
@@ -1,0 +1,65 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+libc = lib/include
+clang-args =
+clang-cflags = -fno-builtin -nostdlib -std=c99 -I$libc -Wall
+# Note: you need to add a symlink in the local directory that points to the
+# appropriate version of Xcode you want to use; e.g.:
+#
+#     $ ln -s /Applications/Xcode_12.5.app Xcode
+#
+# Since `ninja` doesn't accept flags nor does a `build.ninja` read from
+# environment variables, we need a level of indirection to be able to substitute
+# different versions of Xcode locally vs. what's used in GitHub Actions.
+Xcode_UsrLib = Xcode/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib
+
+rule clang
+  depfile = $out.d
+  command = clang -O2 -MD -MF $out.d ${clang-cflags} ${clang-args} -c $in -o $out
+
+rule ar
+  command = ar -crs $out $in
+
+rule ld
+  command = ld -arch x86_64 -execute $in -lSystem -L${Xcode_UsrLib} -o $out
+
+build lib/complex.o: clang lib/complex.c
+build lib/libc.a: ar lib/complex.o
+
+rule exit_with_status_code
+  command = tests/exit_with_status_code.sh ${expected-status} ${subcommand}
+
+# Run complex_test (real=2, imaginary=5)
+build tests/complex_test_2_5.o: clang tests/complex_test.c
+  clang-args = -DREAL=2 -DIMAG=5
+
+build tests/complex_test_2_5: ld tests/complex_test_2_5.o lib/libc.a
+
+build run_complex_test_2_5: exit_with_status_code tests/complex_test_2_5
+  expected-status = 7
+  subcommand = tests/complex_test_2_5
+
+# Run complex_test (real=3, imaginary=8)
+build tests/complex_test_3_8.o: clang tests/complex_test.c
+  clang-args = -DREAL=3 -DIMAG=8
+
+build tests/complex_test_3_8: ld tests/complex_test_3_8.o
+
+build run_complex_test_3_8: exit_with_status_code tests/complex_test_3_8
+  expected-status = 11
+  subcommand = tests/complex_test_3_8
+
+# Run all tests
+build test: phony | run_complex_test_2_5 run_complex_test_3_8

--- a/lib/crt0.c
+++ b/lib/crt0.c
@@ -1,0 +1,21 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdlib.h>
+
+extern int main(int argc, char* argv[]);
+
+void _start(int argc, char* argv[]) {
+  exit(main(argc, argv));
+}

--- a/lib/include/stdlib.h
+++ b/lib/include/stdlib.h
@@ -1,0 +1,21 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _LIBC_STDLIB_H_
+#define _LIBC_STDLIB_H_
+
+// 7.20.4.3 The exit function
+void exit(int status);
+
+#endif  // _LIBC_STDLIB_H_

--- a/lib/stdlib.c
+++ b/lib/stdlib.c
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdlib.h>
+
+// Relevant docs:
+//
+// * How system calls work on Linux (covers 32-bit and 64-bit):
+//   https://blog.packagecloud.io/eng/2016/04/05/the-definitive-guide-to-linux-system-calls/
+// * 64-bit system call numbers (this points to syscall 231, `sys_exit_group`):
+//   https://github.com/torvalds/linux/blob/17ae69aba89dbfa2139b7f8024b757ab3cc42f59/arch/x86/entry/syscalls/syscall_64.tbl#L242
+// * https://man7.org/linux/man-pages/man3/exit.3.html
+// * https://man7.org/linux/man-pages/man2/exit.2.html
+// * https://man7.org/linux/man-pages/man2/_exit.2.html
+// * https://pubs.opengroup.org/onlinepubs/7908799/xsh/_exit.html
+// * https://stackoverflow.com/questions/46903180/syscall-implementation-of-exit
+
+// TODO(mbrukman): this function definition is not complete as we are not
+// handling all the relevant cleanup operations that need to happen here.
+void exit(int status) {
+#if defined(__linux__) && defined(__LP64__)
+  const unsigned long sys_exit_group = 231;
+  __asm("movq %0, %%rax\n"
+        "movq %1, %%rdi\n"
+        "syscall"
+        : // no outputs
+        : "m" (sys_exit_group), "m" (status)
+        : "rax", "rdi");
+#else
+#  error "This OS is not 64-bit Linux (not yet supported)."
+#endif
+}


### PR DESCRIPTION
Turns out, by default, Clang generates code with soft-float support even though
we're on x86_64 which has hardware floating point support, and yet no amount of
`-ffast-math` or `-march` or `-mcpu` or `-mfloat-abi=hard` or `-target` help
avoiding generating calls to `__mulsc3()` which requires a complex
implementation to properly handle Inf and NaN values.

Instead, just adding the flat `-O2` to the Clang compilation command-line helps
avoiding the generation of calls to soft-float code.

Add stub implementation of `exit()` which calls the Linux system call
`sys_exit_group()` without any requisite cleanup of streams, etc. These will be
handled in the future.

Since we now need customization of compilation and linking command-lines for
macOS vs. Linux, bifurcate the Ninja build files to keep them separate until we
start generating them from another canonical source.