### PR TITLE
Document Linux support and Clang 12 requirement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
+      - name: Show Clang version
+        run: clang --version
+
       - name: Download Ninja
         run: curl -OL https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip
 
@@ -46,6 +49,9 @@ jobs:
 
       - name: Create symlink to Xcode
         run: ln -s /Applications/Xcode_12.4.app Xcode
+
+      - name: Show Clang version
+        run: clang --version
 
       - name: Download Ninja
         run: curl -OL https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-mac.zip

--- a/README.md
+++ b/README.md
@@ -18,17 +18,27 @@ are [plenty of options][c-std-libs] to choose from.
 
 ## Build & test
 
-> Note: currently, we only support macOS; we will soon fix this.
+### Linux
 
-1. Install Xcode and accept the license agreement
-1. Create a symlink pointing to the Xcode app in your Applications folder, e.g.,
+1. Install Clang 12 or higher; the LLVM project provides [APT repos][llvm-apt]
+   for easy installation on Debian and Ubuntu.
+1. Install [Ninja][ninja].
+1. Build libc and run tests via: `ninja -f build-linux.ninja test`
+
+### macOS
+
+1. Install Xcode 12.0 or higher and accept the license agreement. We need Clang
+   12 or higher; Xcode 12 appears to be the earliest version of Xcode to ship
+   with Clang 12.
+
+1. Create a symlink pointing to the Xcode app in your Applications folder, e.g.:
 
    ```sh
    $ ln -s /Applications/Xcode_12.4.app Xcode
    ```
 
-1. Install [Ninja][ninja]
-1. Run `ninja test`
+1. Install [Ninja][ninja].
+1. Build libc and run tests via: `ninja -f build-macos.ninja test`
 
 ## Contributing
 
@@ -49,4 +59,5 @@ merchantability, or fitness for a particular purpose.
 [c-std-libs]: https://en.wikipedia.org/wiki/C_standard_library#Implementations
 [iso-c-std]: http://www.iso-9899.info/wiki/The_Standard
 [posix-std]: https://pubs.opengroup.org/onlinepubs/9699919799/
+[llvm-apt]: https://apt.llvm.org/
 [ninja]: https://github.com/ninja-build/ninja


### PR DESCRIPTION
Also add command to verify the version of Clang in our testing environment on
GitHub Actions to ensure we're using an appropriate version of Clang, or we'll
learn that we can relax our requirements of it works with an earlier version as
well.