### PR TITLE
Add `__attribute__((used))` to library functions

### DIFF
--- a/lib/complex.c
+++ b/lib/complex.c
@@ -15,27 +15,33 @@
 #include <complex.h>
 
 // 7.3.9.2 The cimag functions
+__attribute__((used))
 double cimag(double complex z) {
   return ((_Complex_Double*) &z)->imag;
 }
 
+__attribute__((used))
 float cimagf(float complex z) {
   return ((_Complex_Float*) &z)->imag;
 }
 
+__attribute__((used))
 long double cimagl(long double complex z) {
   return ((_Complex_Long_Double*) &z)->imag;
 }
 
 // 7.3.9.6 The creal functions
+__attribute__((used))
 double creal(double complex z) {
   return ((_Complex_Double*) &z)->real;
 }
 
+__attribute__((used))
 float crealf(float complex z) {
   return ((_Complex_Float*) &z)->real;
 }
 
+__attribute__((used))
 long double creall(long double complex z) {
   return ((_Complex_Long_Double*) &z)->real;
 }

--- a/lib/stdlib.c
+++ b/lib/stdlib.c
@@ -28,6 +28,7 @@
 
 // TODO(mbrukman): this function definition is not complete as we are not
 // handling all the relevant cleanup operations that need to happen here.
+__attribute__((used))
 void exit(int status) {
 #if defined(__linux__) && defined(__LP64__)
   const unsigned long sys_exit_group = 231;


### PR DESCRIPTION
Now that we're using the `-O2` flag, Clang may be removing some of our
functions due to the fact that they're not themselves used in our libc;
however, this behavior appears to be non-deterministic:

1. During the PR tests, the build and tests all succeeded:
   https://github.com/mbrukman/c-stdlib/pull/4/checks?check_run_id=2588271677

2. However, after the PR was merged into `main`, the same test failed:
   https://github.com/mbrukman/c-stdlib/runs/2588277889?check_suite_focus=true

   ```
   FAILED: tests/complex_test_3_8
   ld tests/complex_test_3_8.o lib/libc.a -o tests/complex_test_3_8
   ld: warning: cannot find entry symbol _start; defaulting to 0000000000401000
   ld: tests/complex_test_3_8.o: in function `main':
   complex_test.c:(.text+0x12): undefined reference to `creal'
   ld: complex_test.c:(.text+0x2c): undefined reference to `cimag'
   ```

It's unclear whether the non-determinism is coming from GitHub's proprietary
environment, Ninja, Clang, or something else, so let's add explicit annotations
that these functions should not be removed despite lack of explicit references
from the library itself.