### PR TITLE
Make `lib/libc.a` explicit input of `ld` command

### DIFF
--- a/build-linux.ninja
+++ b/build-linux.ninja
@@ -24,7 +24,7 @@ rule ar
   command = ar -crs $out $in
 
 rule ld
-  command = ld $in lib/libc.a -o $out
+  command = ld $in -o $out
 
 build lib/complex.o: clang lib/complex.c
 build lib/crt0.o: clang lib/crt0.c
@@ -48,7 +48,7 @@ build run_complex_test_2_5: exit_with_status_code tests/complex_test_2_5
 build tests/complex_test_3_8.o: clang tests/complex_test.c
   clang-args = -DREAL=3 -DIMAG=8
 
-build tests/complex_test_3_8: ld tests/complex_test_3_8.o
+build tests/complex_test_3_8: ld tests/complex_test_3_8.o lib/libc.a
 
 build run_complex_test_3_8: exit_with_status_code tests/complex_test_3_8
   expected-status = 11

--- a/build-macos.ninja
+++ b/build-macos.ninja
@@ -55,7 +55,7 @@ build run_complex_test_2_5: exit_with_status_code tests/complex_test_2_5
 build tests/complex_test_3_8.o: clang tests/complex_test.c
   clang-args = -DREAL=3 -DIMAG=8
 
-build tests/complex_test_3_8: ld tests/complex_test_3_8.o
+build tests/complex_test_3_8: ld tests/complex_test_3_8.o lib/libc.a
 
 build run_complex_test_3_8: exit_with_status_code tests/complex_test_3_8
   expected-status = 11


### PR DESCRIPTION
Make `complex_test_3_8` link command consistent with `complex_test_2_5` by
explicitly specifying `lib/libc.a` as one of the inputs to ensure that it's
always built prior to linking; otherwise, we get non-deterministic failures
such as: https://github.com/mbrukman/c-stdlib/runs/2588317234

Remove the implicit usage of `lib/libc.a` from the `ld` command line, and
rely on it being specified by the callers, which will ensure it's both always
rebuilt before linking, and also not specified twice if it's supplied both
explicitly and implicitly.