### PR TITLE
Simplify complex_test via single compilation mode

### DIFF
--- a/build-linux.ninja
+++ b/build-linux.ninja
@@ -31,28 +31,17 @@ build lib/crt0.o: clang lib/crt0.c
 build lib/stdlib.o: clang lib/stdlib.c
 build lib/libc.a: ar lib/complex.o lib/crt0.o lib/stdlib.o
 
+expected-status = 0
 rule exit_with_status_code
   command = tests/exit_with_status_code.sh ${expected-status} ${subcommand}
 
-# Run complex_test (real=2, imaginary=5)
-build tests/complex_test_2_5.o: clang tests/complex_test.c
-  clang-args = -DREAL=2 -DIMAG=5
+# Run complex_test
+build tests/complex_test.o: clang tests/complex_test.c
 
-build tests/complex_test_2_5: ld tests/complex_test_2_5.o lib/libc.a
+build tests/complex_test: ld tests/complex_test.o lib/libc.a
 
-build run_complex_test_2_5: exit_with_status_code tests/complex_test_2_5
-  expected-status = 7
-  subcommand = tests/complex_test_2_5
-
-# Run complex_test (real=3, imaginary=8)
-build tests/complex_test_3_8.o: clang tests/complex_test.c
-  clang-args = -DREAL=3 -DIMAG=8
-
-build tests/complex_test_3_8: ld tests/complex_test_3_8.o lib/libc.a
-
-build run_complex_test_3_8: exit_with_status_code tests/complex_test_3_8
-  expected-status = 11
-  subcommand = tests/complex_test_3_8
+build run_complex_test: exit_with_status_code tests/complex_test
+  subcommand = tests/complex_test
 
 # Run all tests
-build test: phony | run_complex_test_2_5 run_complex_test_3_8
+build test: phony | run_complex_test

--- a/build-macos.ninja
+++ b/build-macos.ninja
@@ -38,28 +38,17 @@ rule ld
 build lib/complex.o: clang lib/complex.c
 build lib/libc.a: ar lib/complex.o
 
+expected-status = 0
 rule exit_with_status_code
   command = tests/exit_with_status_code.sh ${expected-status} ${subcommand}
 
-# Run complex_test (real=2, imaginary=5)
-build tests/complex_test_2_5.o: clang tests/complex_test.c
-  clang-args = -DREAL=2 -DIMAG=5
+# Run complex_test
+build tests/complex_test.o: clang tests/complex_test.c
 
-build tests/complex_test_2_5: ld tests/complex_test_2_5.o lib/libc.a
+build tests/complex_test: ld tests/complex_test.o lib/libc.a
 
-build run_complex_test_2_5: exit_with_status_code tests/complex_test_2_5
-  expected-status = 7
-  subcommand = tests/complex_test_2_5
-
-# Run complex_test (real=3, imaginary=8)
-build tests/complex_test_3_8.o: clang tests/complex_test.c
-  clang-args = -DREAL=3 -DIMAG=8
-
-build tests/complex_test_3_8: ld tests/complex_test_3_8.o lib/libc.a
-
-build run_complex_test_3_8: exit_with_status_code tests/complex_test_3_8
-  expected-status = 11
-  subcommand = tests/complex_test_3_8
+build run_complex_test: exit_with_status_code tests/complex_test
+  subcommand = tests/complex_test
 
 # Run all tests
-build test: phony | run_complex_test_2_5 run_complex_test_3_8
+build test: phony | run_complex_test

--- a/tests/complex_test.c
+++ b/tests/complex_test.c
@@ -14,15 +14,7 @@
 
 #include <complex.h>
 
-#ifndef REAL
-# error "Must #define REAL (integer) before compiling this file."
-#endif
-
-#ifndef IMAG
-# error "Must #define IMAG (integer) before compiling this file."
-#endif
-
-int main(int argc, char* argv[]) {
+int creal_plus_cimag(int real, int imag) {
   // Technically, this style of initializing a complex value is an extension
   // and is not part of the C99 standard; compiling with `clang -pedantic` will
   // result in a warning:
@@ -39,6 +31,18 @@ int main(int argc, char* argv[]) {
   // That said, we'll need to take a shortcut here at least initially to be able
   // to test creal() and cimag() functions easily without having a functional
   // implementation of any other parts of the C99 standard library.
-  complex double i = REAL + IMAG * I;
-  return creal(i) + cimag(i);
+  complex double c = real + imag * I;
+  return creal(c) + cimag(c);
+}
+
+int main(int argc, char* argv[]) {
+  if (creal_plus_cimag(2, 5) != 7) {
+    return 1;
+  }
+
+  if (creal_plus_cimag(3, 8) != 11) {
+    return 1;
+  }
+
+  return 0;
 }


### PR DESCRIPTION
Instead of recompiling the file several time with different preprocessor symbol
values and outputting the result of the computation in the binary exit code,
just move the computation into the file itself: turns out, we can use variables
for complex number declaration, not just static constants, and thus, we can do
the calculation and comparison directly inside the C file, which is much more
convenient.