### PR TITLE
Test a single function at-a-time in complex_test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ Xcode
 *.o
 *.o.d
 .ninja_*
-tests/complex_test_2_5
-tests/complex_test_3_8
+tests/complex_test

--- a/tests/complex_test.c
+++ b/tests/complex_test.c
@@ -14,35 +14,119 @@
 
 #include <complex.h>
 
-int creal_plus_cimag(int real, int imag) {
-  // Technically, this style of initializing a complex value is an extension
-  // and is not part of the C99 standard; compiling with `clang -pedantic` will
-  // result in a warning:
-  //
-  //     complex initialization specifying real and imaginary components is an extension [-Wcomplex-component-init]
-  //
-  // The C11 standard includes the CMPLX(), CMPLXF(), CMPLXL() macros to help with
-  // this. For more info, see:
-  //
-  // * https://stackoverflow.com/questions/5914590/c99-right-way-to-initialize-complex-variable-with-0-0-0i
-  // * http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1464.htm
-  // * https://en.cppreference.com/w/c/numeric/complex/CMPLX
-  //
-  // That said, we'll need to take a shortcut here at least initially to be able
-  // to test creal() and cimag() functions easily without having a functional
-  // implementation of any other parts of the C99 standard library.
-  complex double c = real + imag * I;
-  return creal(c) + cimag(c);
+// Technically, the style of initializing complex values in this file is an
+// extension and is not part of the C99 standard; compiling with `clang
+// -pedantic` will result in a warning:
+//
+//     complex initialization specifying real and imaginary components is an extension [-Wcomplex-component-init]
+//
+// The C11 standard includes the make_complex(), make_complexF(), make_complexL() macros to help with
+// this. For more info, see:
+//
+// * https://stackoverflow.com/questions/5914590/c99-right-way-to-initialize-complex-variable-with-0-0-0i
+// * http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1464.htm
+// * https://en.cppreference.com/w/c/numeric/complex/make_complex
+//
+// That said, we'll need to take a shortcut here at least initially to be able
+// to test creal() and cimag() functions easily without having a functional
+// implementation of any other parts of the C99 standard library.
+
+// 7.3.9.2 The cimag functions
+int cimag_test() {
+  int num_failures = 0;
+
+  if (cimag(2 + 5 * I) != 5) {
+    num_failures++;
+  }
+  if (cimag(-3 - 8 * I) != -8) {
+    num_failures++;
+  }
+
+  return num_failures;
+}
+
+int cimagf_test() {
+  int num_failures = 0;
+
+  if (cimagf(2 + 5 * I) != 5) {
+    num_failures++;
+  }
+  if (cimagf(-3 - 8 * I) != -8) {
+    num_failures++;
+  }
+
+  return num_failures;
+}
+
+int cimagl_test() {
+  int num_failures = 0;
+
+  if (cimagl(2 + 5 * I) != 5) {
+    num_failures++;
+  }
+  if (cimagl(-3 - 8 * I) != -8) {
+    num_failures++;
+  }
+
+  return num_failures;
+}
+
+// 7.3.9.6 The creal functions
+int creal_test() {
+  int num_failures = 0;
+
+  if (creal(2 + 5 * I) != 2) {
+    num_failures++;
+  }
+  if (creal(-3 - 8 * I) != -3) {
+    num_failures++;
+  }
+
+  return num_failures;
+}
+
+int crealf_test() {
+  int num_failures = 0;
+
+  if (crealf(2 + 5 * I) != 2) {
+    num_failures++;
+  }
+  if (crealf(-3 - 8 * I) != -3) {
+    num_failures++;
+  }
+
+  return num_failures;
+}
+
+int creall_test() {
+  int num_failures = 0;
+
+  if (creall(2 + 5 * I) != 2) {
+    num_failures++;
+  }
+  if (creall(-3 - 8 * I) != -3) {
+    num_failures++;
+  }
+
+  return num_failures;
 }
 
 int main(int argc, char* argv[]) {
-  if (creal_plus_cimag(2, 5) != 7) {
-    return 1;
-  }
+  int num_failures = 0;
 
-  if (creal_plus_cimag(3, 8) != 11) {
-    return 1;
-  }
+  // 7.3.9.2 The cimag functions
+  num_failures += cimag_test();
 
-  return 0;
+  // TODO(mbrukman): enable these tests once they work on Linux.
+  // num_failures += cimagf_test();
+  // num_failures += cimagl_test();
+
+  // 7.3.9.6 The creal functions
+  num_failures += creal_test();
+
+  // TODO(mbrukman): enable these tests once they work on Linux.
+  // num_failures += crealf_test();
+  // num_failures += creall_test();
+
+  return num_failures;
 }


### PR DESCRIPTION
Rather than testing an expression consisting of the output of  several
functions, test each function independently, so we can see which function(s) are
working vs. which ones are failing and in which context. This will make it
easier to see what's working vs.  what isn't.

Also add similar tests for cimagf(), cimagl(), crealf(), and creall().