### PR TITLE
Rename tool-specific rules to generic names

### DIFF
--- a/build-linux.ninja
+++ b/build-linux.ninja
@@ -16,14 +16,14 @@ libc = lib/include
 clang-args =
 clang-cflags = -fno-builtin -nostdlib -std=c99 -I$libc -Wall
 
-rule clang
+rule compile
   depfile = $out.d
   command = clang -O2 -MD -MF $out.d ${clang-cflags} ${clang-args} -c $in -o $out
 
 rule ar
   command = ar -crs $out $in
 
-rule ld
+rule link
   command = ld $in -o $out
 
 include libc.ninja

--- a/build-macos.ninja
+++ b/build-macos.ninja
@@ -25,14 +25,14 @@ clang-cflags = -fno-builtin -nostdlib -std=c99 -I$libc -Wall
 # different versions of Xcode locally vs. what's used in GitHub Actions.
 Xcode_UsrLib = Xcode/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib
 
-rule clang
+rule compile
   depfile = $out.d
   command = clang -O2 -MD -MF $out.d ${clang-cflags} ${clang-args} -c $in -o $out
 
 rule ar
   command = ar -crs $out $in
 
-rule ld
+rule link
   command = ld -arch x86_64 -e __start $in -lSystem -L${Xcode_UsrLib} -o $out
 
 include libc.ninja

--- a/libc.ninja
+++ b/libc.ninja
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build lib/complex.o: clang lib/complex.c
-build lib/crt0.o: clang lib/crt0.c
-build lib/math.o: clang lib/math.c
-build lib/stdlib.o: clang lib/stdlib.c
+build lib/complex.o: compile lib/complex.c
+build lib/crt0.o: compile lib/crt0.c
+build lib/math.o: compile lib/math.c
+build lib/stdlib.o: compile lib/stdlib.c
 build lib/libc.a: ar lib/complex.o lib/crt0.o lib/math.o lib/stdlib.o

--- a/tests.ninja
+++ b/tests.ninja
@@ -17,25 +17,25 @@ rule exit_with_status_code
   command = tests/exit_with_status_code.sh ${expected-status} ${subcommand}
 
 # Run complex_test
-build tests/complex_test.o: clang tests/complex_test.c
+build tests/complex_test.o: compile tests/complex_test.c
 
-build tests/complex_test: ld tests/complex_test.o lib/libc.a
+build tests/complex_test: link tests/complex_test.o lib/libc.a
 
 build run_complex_test: exit_with_status_code tests/complex_test
   subcommand = tests/complex_test
 
 # Run math_test
-build tests/math_test.o: clang tests/math_test.c
+build tests/math_test.o: compile tests/math_test.c
 
-build tests/math_test: ld tests/math_test.o lib/libc.a
+build tests/math_test: link tests/math_test.o lib/libc.a
 
 build run_math_test: exit_with_status_code tests/math_test
   subcommand = tests/math_test
 
 # Run stdlib_test
-build tests/stdlib_test.o: clang tests/stdlib_test.c
+build tests/stdlib_test.o: compile tests/stdlib_test.c
 
-build tests/stdlib_test: ld tests/stdlib_test.o lib/libc.a
+build tests/stdlib_test: link tests/stdlib_test.o lib/libc.a
 
 build run_stdlib_test: exit_with_status_code tests/stdlib_test
   subcommand = tests/stdlib_test


### PR DESCRIPTION
`clang` -> `compile`, `ld` -> `link`