### PR TITLE
Simplify exit() implementation via syscall

### DIFF
--- a/tests.ninja
+++ b/tests.ninja
@@ -32,6 +32,24 @@ build tests/math_test: link tests/math_test.o lib/libc.a
 build run_math_test: exit_with_status_code tests/math_test
   subcommand = tests/math_test
 
+# Run stdlib_exit_42_test
+build tests/stdlib_exit_42_test.o: compile tests/stdlib_exit_42_test.c
+
+build tests/stdlib_exit_42_test: link tests/stdlib_exit_42_test.o lib/libc.a
+
+build run_stdlib_exit_42_test: exit_with_status_code tests/stdlib_exit_42_test
+  subcommand = tests/stdlib_exit_42_test
+  expected-status = 42
+
+# Run stdlib_return_42_test
+build tests/stdlib_return_42_test.o: compile tests/stdlib_return_42_test.c
+
+build tests/stdlib_return_42_test: link tests/stdlib_return_42_test.o lib/libc.a
+
+build run_stdlib_return_42_test: exit_with_status_code tests/stdlib_return_42_test
+  subcommand = tests/stdlib_return_42_test
+  expected-status = 42
+
 # Run stdlib_test
 build tests/stdlib_test.o: compile tests/stdlib_test.c
 
@@ -41,4 +59,4 @@ build run_stdlib_test: exit_with_status_code tests/stdlib_test
   subcommand = tests/stdlib_test
 
 # Run all tests
-build test: phony | run_complex_test run_math_test run_stdlib_test
+build test: phony | run_complex_test run_math_test run_stdlib_exit_42_test run_stdlib_return_42_test run_stdlib_test

--- a/tests/stdlib_exit_42_test.c
+++ b/tests/stdlib_exit_42_test.c
@@ -1,0 +1,19 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdlib.h>
+
+int main(int argc, char* argv[]) {
+  exit(42);
+}

--- a/tests/stdlib_return_42_test.c
+++ b/tests/stdlib_return_42_test.c
@@ -1,0 +1,19 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdlib.h>
+
+int main(int argc, char* argv[]) {
+  return 42;
+}


### PR DESCRIPTION
Transfer syscall identifier and status code via registers rather than specifying
memory constraint. Add tests with a constant to verify that it works correctly.