### PR TITLE
README updates: GitHub Actions badge + macOS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status][github-ci-badge]][github-ci-url]
 
-[github-ci-badge]: https://github.com/mbrukman/c-stdlib/actions/workflows/main.yml/badge.svg
-[github-ci-url]: https://github.com/mbrukman/c-stdlib/actions/workflows/main.yml
+[github-ci-badge]: https://github.com/mbrukman/c-stdlib/actions/workflows/main.yml/badge.svg?branch=main
+[github-ci-url]: https://github.com/mbrukman/c-stdlib/actions/workflows/main.yml?query=branch%3Amain
 
 This project aims to implement the C standard library.
 
@@ -28,11 +28,14 @@ are [plenty of options][c-std-libs] to choose from.
 ### macOS
 
 1. Install Xcode and accept the license agreement.
-1. Create a symlink pointing to the Xcode app in your Applications folder, e.g.:
+1. Create a symlink in this directory pointing to the Xcode app in your
+   `Applications` folder, e.g.:
 
    ```sh
-   $ ln -s /Applications/Xcode_12.4.app Xcode
+   $ ln -s /Applications/Xcode_12.5.app Xcode
    ```
+
+   See the comment in [`macos.ninja`](macos.ninja) for details and rationale.
 
 1. Install [Ninja][ninja].
 1. Build libc and run tests via: `ninja -f macos.ninja test`


### PR DESCRIPTION
* update GitHub Actions badge and URL to point to the `main` branch; previously, it was linking to the default view, which would show a failure if a recent PR was failing, but that doesn't say anything about the `main` branch which we aim to keep stable
* clarify instructions for why we need to create a symlink to the Xcode app on macOS and provide a reference to the `macos.ninja` file which provides more information

Since this is not modifying any code, we can [skip ci] and save some CPU cycles.