### PR TITLE
Split GitHub Actions workflow into Linux + macOS

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,45 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Linux
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  Build-and-test:
+    strategy:
+      matrix:
+        os: [ 'ubuntu-20.04', 'ubuntu-22.04' ]
+
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Show Clang version
+        run: clang --version
+
+      - name: Download Ninja
+        run: curl -OL https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip
+
+      - name: Unzip Ninja
+        run: unzip ninja-linux.zip
+
+      - name: Build and run tests
+        run: ./ninja -f linux.ninja test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Build & test"
+name: macOS
 
 on:
   push:
@@ -21,30 +21,7 @@ on:
     branches: [ main ]
 
 jobs:
-  Linux:
-    strategy:
-      matrix:
-        os: [ 'ubuntu-20.04', 'ubuntu-22.04' ]
-
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Show Clang version
-        run: clang --version
-
-      - name: Download Ninja
-        run: curl -OL https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip
-
-      - name: Unzip Ninja
-        run: unzip ninja-linux.zip
-
-      - name: Build and run tests
-        run: ./ninja -f linux.ninja test
-
-  macOS:
+  Build-and-test:
     strategy:
       matrix:
         include:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # C standard library
 
-[![Build Status][github-ci-badge]][github-ci-url]
+[![Linux build status][linux-ci-badge]][linux-ci-url] [![macOS build status][macos-ci-badge]][macos-ci-url]
 
-[github-ci-badge]: https://github.com/mbrukman/c-stdlib/actions/workflows/main.yml/badge.svg?branch=main
-[github-ci-url]: https://github.com/mbrukman/c-stdlib/actions/workflows/main.yml?query=branch%3Amain
+[linux-ci-badge]: https://github.com/mbrukman/c-stdlib/actions/workflows/linux.yml/badge.svg?branch=main
+[linux-ci-url]: https://github.com/mbrukman/c-stdlib/actions/workflows/linux.yml?query=branch%3Amain
+[macos-ci-badge]: https://github.com/mbrukman/c-stdlib/actions/workflows/macos.yml/badge.svg?branch=main
+[macos-ci-url]: https://github.com/mbrukman/c-stdlib/actions/workflows/macos.yml?query=branch%3Amain
 
 This project aims to implement the C standard library.
 


### PR DESCRIPTION
This will let us show separate badges in the README to show the status independently, with more meaningful names rather than the generic "build & test".

While this may also provide additional parallelism, we don't actually need it: the Linux build is extremely fast (~6 sec) and the macOS is the slow one.