### PR TITLE
Update Ninja from v1.10.2 to v1.11.1

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
         run: clang --version
 
       - name: Download Ninja
-        run: curl -OL https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip
+        run: curl -OL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip
 
       - name: Unzip Ninja
         run: unzip ninja-linux.zip

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,7 +49,7 @@ jobs:
         run: clang --version
 
       - name: Download Ninja
-        run: curl -OL https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-mac.zip
+        run: curl -OL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip
 
       - name: Unzip Ninja
         run: unzip ninja-mac.zip


### PR DESCRIPTION
Release notes: https://github.com/ninja-build/ninja/releases/tag/v1.11.1