### PR TITLE
Add Ubuntu 24.04; remove Ubuntu 20.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
   Build-and-test:
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04', 'ubuntu-22.04' ]
+        os: [ 'ubuntu-24.04', 'ubuntu-22.04' ]
 
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Ubuntu 20.04 is 4+ years old now and will likely be removed soon.