### PR TITLE
Specify file paths relevant per platform CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,11 +14,36 @@
 
 name: Linux
 
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
 on:
   push:
     branches: [ main ]
+    paths:
+        # Source code and build rules
+      - 'lib/**'
+      - 'libc.ninja'
+        # Test code and build rules
+      - 'tests/**'
+      - 'tests.ninja'
+        # Linux-specific build rules and configs
+      - 'linux.ninja'
+      - '.github/workflows/linux.yml'  # this file
+
   pull_request:
     branches: [ main ]
+    paths:
+        # Source code and build rules
+      - 'lib/**'
+      - 'libc.ninja'
+        # Test code and build rules
+      - 'tests/**'
+      - 'tests.ninja'
+        # Linux-specific build rules and configs
+      - 'linux.ninja'
+      - '.github/workflows/linux.yml'  # this file
+
   schedule:
     # Run at 08:08 on the 1st day of each month
     - cron: '8 8 1 * *'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,11 +14,36 @@
 
 name: macOS
 
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
 on:
   push:
     branches: [ main ]
+    paths:
+        # Source code and build rules
+      - 'lib/**'
+      - 'libc.ninja'
+        # Test code and build rules
+      - 'tests/**'
+      - 'tests.ninja'
+        # macOS-specific build rules and configs
+      - 'macos.ninja'
+      - '.github/workflows/macos.yml'  # this file
+
   pull_request:
     branches: [ main ]
+    paths:
+        # Source code and build rules
+      - 'lib/**'
+      - 'libc.ninja'
+        # Test code and build rules
+      - 'tests/**'
+      - 'tests.ninja'
+        # macOS-specific build rules and configs
+      - 'macos.ninja'
+      - '.github/workflows/macos.yml'  # this file
+
   schedule:
     # Run at 08:08 on the 1st day of each month
     - cron: '8 8 1 * *'


### PR DESCRIPTION
We don't need to run macOS tests when we're modifying the Linux CI config or Linux-specific build rules, and vice versa, so specify the shared and platform-specific paths to avoid running extra CI builds/tests when they're not necessary.